### PR TITLE
Update to new URL & openAPI generator

### DIFF
--- a/build_domain_client_library.sh
+++ b/build_domain_client_library.sh
@@ -3,22 +3,22 @@
 echo "Generating client..."
 
 # Location of the Swagger Config
-SWAGGER_DOCUMENT="https://developer.domain.com.au/docs/media/public-adapter-v1.json"
+SWAGGER_DOCUMENT="https://developer.domain.com.au/static/latest/media/v1/openapi.json"
 CLIENT_NAME="domainClient"
 
-JSON_FMT='{"options":{"packageName": "%s"},"swaggerUrl":"%s"}'
+JSON_FMT='{"options":{"packageName": "%s"},"openAPIUrl":"%s"}'
 JSON_REQUEST=$(printf "$JSON_FMT" $CLIENT_NAME $SWAGGER_DOCUMENT)
 
 response=$(
     curl -X POST \
         -H "content-type:application/json" \
         -d "$JSON_REQUEST" \
-        https://generator.swagger.io/api/gen/clients/python
+        http://api.openapi-generator.tech/api/gen/clients/python
     )
 echo "Generating client...Done"
 
 
-LINK_URL="$(echo $response | grep -Eo 'https:[^"]+')"
+LINK_URL="$(echo $response | grep -Eo 'http:[^"]+')"
 
 echo "Downloading $CLIENT_NAME..."
 curl "$LINK_URL" -o "$CLIENT_NAME.zip"


### PR DESCRIPTION
Fixes #34 

Provides two key updates:

1. The URL for the domain API spec was outdated & has now been updated to the current V1 URL
2. The API generator was failing & has thus been updated from using the swagger codegen API to the openAPI generator API